### PR TITLE
Fixed some typo

### DIFF
--- a/docs/source/applications/access.rst
+++ b/docs/source/applications/access.rst
@@ -23,7 +23,7 @@ In order to access the SCION production network, your network provider must prov
 Setting up the SCION endhost stack
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can install and configure the SCION endhost stack for **Linux, macOS, or Windows** using the `SCION orchastrator for endhosts <https://github.com/netsys-lab/scion-orchestrator>`_.
+You can install and configure the SCION endhost stack for **Linux, macOS, or Windows** using the `SCION orchestrator for endhosts <https://github.com/netsys-lab/scion-orchestrator>`_.
 
 Alternatively, you can use the `SCION endhost bootstrapper <https://github.com/netsec-ethz/bootstrapper>`_ to fetch the SCION configuration.
 On Debian systems, the bootstrapper will also install the SCION endhost stack for you.
@@ -66,7 +66,7 @@ Depending on where you compile the binaries, you may need to specify ``GOOS=wind
 SCIONLab network
 ----------------
 The SCIONLab network is a global testbed (not production) that runs as SCION as an overlay network protocol. 
-It is used for experimental purposes, altough one can deploy real applications on it. 
+It is used for experimental purposes, although one can deploy real applications on it. 
 It is free to use and open to everyone, but one cannot expect the same level of reliability, performance and security as the SCION production network.
 
 In order to access the SCIONLab network, you must have a SCIONLab account and have set up a SCIONLab node (see https://docs.scionlab.org/).

--- a/docs/source/applications/ioq3-scion.rst
+++ b/docs/source/applications/ioq3-scion.rst
@@ -200,7 +200,7 @@ download the original game's demo for free (with limited content).
 Full Game
 """""""""
 Copy the ``.pk3`` files from the original game's `baseq3` and `missionpack` directories
-into the same diretories in ioq3-scion's *homepath*. By providing the ``.qvm`` files in the ``vm``
+into the same directories in ioq3-scion's *homepath*. By providing the ``.qvm`` files in the ``vm``
 subdirectories we override the code from the original game while keeping the remaining assets.
 
 Demo
@@ -270,7 +270,7 @@ ephemeral ports.
 
 Directory Structure
 -------------------
-You should now have to following directory structure.
+You should now have the following directory structure.
 
 Linux
 """""
@@ -498,11 +498,11 @@ Server Commands
 - Command: ``clearclientpaths`` Clear the remote host cache of the server's path selector.
 - Command: ``heartbeat`` Send heartbeat to master servers.
 - Command: ``kick <player name>`` Kick a player from the server.
-- Command: ``banaddr (ip[/subnet] | clientnum [subnet])`` Band an IP or ISD-ASN,IP.
+- Command: ``banaddr (ip[/subnet] | clientnum [subnet])`` Ban an IP or ISD-ASN,IP.
 - Command: ``exceptaddr (ip[/subnet] | clientnum [subnet])`` Exclude an IP or ISD-ASN,IP from a ban.
 - Command: ``bandel (ip[/subnet] | num)`` Remove a ban.
 - Command: ``exceptdel (ip[/subnet] | num)`` Remove an exception.
-- Command: ``listbans`` List bans and excpetions.
+- Command: ``listbans`` List bans and exceptions.
 
 Network
 -------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,7 +42,7 @@ Their documentation is not guaranteed to be hosted in this site indefinitely.
    Bittorrent <applications/bittorrent>
    Echo SCION <applications/echoscion>
    Hercules <applications/hercules>
-   IFPS <applications/ipfs>
+   IPFS <applications/ipfs>
    HTTP Proxy <https://scion-http-proxy.readthedocs.io/en/latest/index.html>
    Browser Extension <https://scion-browser-extension.readthedocs.io/en/latest/>
    Quake III Arena <applications/ioq3-scion.rst>


### PR DESCRIPTION
This pull request focuses on fixing typographical errors and improving clarity in the documentation files.

### Typographical Fixes:

* [`docs/source/applications/access.rst`](diffhunk://#diff-41b5c03745c0f4b7129440644e539cb612d70e486132ef187582fb6cc055c44eL26-R26): Corrected "orchastrator" to "orchestrator" and "altough" to "although" to fix spelling errors. [[1]](diffhunk://#diff-41b5c03745c0f4b7129440644e539cb612d70e486132ef187582fb6cc055c44eL26-R26) [[2]](diffhunk://#diff-41b5c03745c0f4b7129440644e539cb612d70e486132ef187582fb6cc055c44eL69-R69)
* [`docs/source/applications/ioq3-scion.rst`](diffhunk://#diff-288b593d0c8653e6a274d4f26692983e007cb0aed98f6f51783358f2143ccab7L203-R203): Fixed typos such as "diretories" to "directories," "to following" to "the following," and "excpetions" to "exceptions." [[1]](diffhunk://#diff-288b593d0c8653e6a274d4f26692983e007cb0aed98f6f51783358f2143ccab7L203-R203) [[2]](diffhunk://#diff-288b593d0c8653e6a274d4f26692983e007cb0aed98f6f51783358f2143ccab7L273-R273) [[3]](diffhunk://#diff-288b593d0c8653e6a274d4f26692983e007cb0aed98f6f51783358f2143ccab7L501-R505)
* [`docs/source/index.rst`](diffhunk://#diff-4eec6cec5f6fab1548b85433ea8ca81315ae165db4b7f84019f287df9015699fL45-R45): Corrected "IFPS" to "IPFS" for accurate terminology.

### Command Descriptions:

* [`docs/source/applications/ioq3-scion.rst`](diffhunk://#diff-288b593d0c8653e6a274d4f26692983e007cb0aed98f6f51783358f2143ccab7L501-R505): Fixed "Band" to "Ban" in the `banaddr` command description to ensure correct usage.