### PR TITLE
fix code block rendering

### DIFF
--- a/docs/source/applications/ipfs.rst
+++ b/docs/source/applications/ipfs.rst
@@ -8,7 +8,9 @@ The SCION Education Network will soon run some IPFS nodes including some content
 To setup IPFS over SCION on your node, follow these instructions. At first, download the proper binary from our `releases site <https://github.com/netsys-lab/sciera-releases/tree/main/ipfs/latest>`_.
 
 Start some nodes by replacing {ISD-AS} with your ISD-AS combination and {IP} with your local IP (must be reachable within your SCION AS).
+
 .. code-block:: console
+
     cd kubo
     mkdir ~/node1
     IPFS_PATH=~/node1 cmd/ipfs/ipfs init -p test
@@ -18,9 +20,11 @@ Start some nodes by replacing {ISD-AS} with your ISD-AS combination and {IP} wit
 
 
 Connect nodes
+
 .. code-block:: console
+
     cd kubo
     IPFS_PATH=~/node1 cmd/ipfs/ipfs swarm connect `IPFS_PATH=~/node2 cmd/ipfs/ipfs id -f="<addrs>"`
-```
+
 
 As soon as all of our IPFS nodes in the network are running and serving content, we will announce their addresses here. You can then connect to them by replacing <addrs> in the previous command.


### PR DESCRIPTION
The two code blocks in the ipfs chapter were not rendered correctly due to missing newlines. This PR fixes it.